### PR TITLE
Change 'like' command to accept search parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ This plugin requires the use of the Spotify Web API, which is only accessible th
 | `` sp shuffle ``                   | Toggle Shuffle Mode                              |
 | `` sp reconnect ``                 | Force a full reconnection                        |
 | `` sp like ``                      | Add the playing track to liked songs             |
-| `` sp remove ``                    | Remove the playing track from liked songs        |
-| `` sp like ``                      | Toggle the like of the playing track             |
+| `` sp like {track name}``          | Search for a track to add to liked songs         |
+| `` sp unlike ``                    | Remove the playing track from liked songs        |
 
 ### Notice
 - Spotify relies on Web Authentication Calls to Connect to the API remotely - you will need to authorize it to use this plugin

--- a/SpotifyPlugin.cs
+++ b/SpotifyPlugin.cs
@@ -65,9 +65,8 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
             _terms.Add("vol", SetVolume);
             _terms.Add("volume", SetVolume);
             _terms.Add("shuffle", ToggleShuffle);
-            _terms.Add("like", AddLikeCurrentSong);
+            _terms.Add("like", ToggleLikeCurrentSong);
             _terms.Add("unlike", UnlikeCurrentSong);
-            _terms.Add("toggle", ToggleLikeCurrentSong);
 
             //view query count and average query duration
             _terms.Add("diag", q =>

--- a/SpotifyPlugin.cs
+++ b/SpotifyPlugin.cs
@@ -56,6 +56,7 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
             _expensiveTerms.Add("playlist", SearchPlaylist);
             _expensiveTerms.Add("device", GetDevices);
             _expensiveTerms.Add("queue", QueueSearch);
+            _expensiveTerms.Add("like", SearchLikeTrack);
 
             _terms.Add("next", PlayNext);
             _terms.Add("last", PlayLast);
@@ -65,7 +66,6 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
             _terms.Add("vol", SetVolume);
             _terms.Add("volume", SetVolume);
             _terms.Add("shuffle", ToggleShuffle);
-            _terms.Add("like", ToggleLikeCurrentSong);
             _terms.Add("unlike", UnlikeCurrentSong);
 
             //view query count and average query duration
@@ -351,17 +351,6 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
             return SingleResultInList("Remove", $"Remove '{currentSong}' from liked songs", action: _client.UnlikeCurrentSong);
         }
 
-        private List<Result> ToggleLikeCurrentSong(string arg = null)
-        {
-            var currentSongName = _client.CurrentPlaybackName;
-            var currentSongId = _client.CurrentPlaybackId;
-            var currentSongIsLiked = _client.CheckLikedById(currentSongId);
-            var subtitle = currentSongIsLiked 
-                ? $"Remove '{currentSongName}' from liked songs" 
-                : $"Add '{currentSongName}' to liked songs";
-            return SingleResultInList("Toggle", subtitle, action: _client.ToggleLikeCurrentSong);
-        }
-
         private async Task<List<Result>> SearchAllAsync(string param)
         {
             if (!_client.ApiConnected) return AuthenticateResult;
@@ -501,6 +490,41 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
 
             await Task.WhenAll(results);
             return searchResults.Any() ? results.Select(x => x.Result).ToList() : NothingFoundResult;
+        }
+
+        private async Task<List<Result>> SearchLikeTrack(string param) {
+            if (!_client.ApiConnected) return AuthenticateResult;
+
+            // Like/Unlike currently playing song if no {track} param is passed
+            if (string.IsNullOrWhiteSpace(param))
+            {
+                var currentSongName = _client.CurrentPlaybackName;
+                var currentSongId = _client.CurrentPlaybackId;
+                var currentSongIsLiked = _client.CheckLikedById(currentSongId);
+                var subtitle = currentSongIsLiked 
+                    ? $"Remove '{currentSongName}' from liked songs" 
+                    : $"Add '{currentSongName}' to liked songs";
+                return SingleResultInList("Like", subtitle, action: _client.ToggleLikeCurrentSong);
+            }
+
+            // Retrieve data and return the first 20 results
+            var searchResults = _client.GetTracks(param).Result;
+            var results = searchResults.Select(async x => new Result()
+            {
+                Title = x.Name,
+                SubTitle = _client.CheckLikedById(x.Id)
+                    ? $"Remove '{x.Name}' by {string.Join(", ", x.Artists.Select(a => a.Name))} from liked songs" 
+                    : $"Add '{x.Name}' by {string.Join(", ", x.Artists.Select(a => a.Name))} to liked songs",
+                IcoPath = await _client.GetArtworkAsync(x),
+                Action = _ =>
+                {
+                    _client.ToggleLikeById(x.Id);
+                    return true;
+                }
+            }).ToArray();
+
+            await Task.WhenAll(results);
+            return results.Any() ? results.Select(x => x.Result).ToList() : NothingFoundResult;
         }
 
         private async Task<List<Result>> GetDevices(string param = null)

--- a/SpotifyPlugin.cs
+++ b/SpotifyPlugin.cs
@@ -66,7 +66,7 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
             _terms.Add("volume", SetVolume);
             _terms.Add("shuffle", ToggleShuffle);
             _terms.Add("like", AddLikeCurrentSong);
-            _terms.Add("remove", RemoveLikeCurrentSong);
+            _terms.Add("unlike", UnlikeCurrentSong);
             _terms.Add("toggle", ToggleLikeCurrentSong);
 
             //view query count and average query duration
@@ -346,10 +346,10 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
             return SingleResultInList("Like", $"Add '{currentSong}' to liked songs", action: _client.AddLikeCurrentSong);
         }
 
-        private List<Result> RemoveLikeCurrentSong(string arg = null)
+        private List<Result> UnlikeCurrentSong(string arg = null)
         {
             var currentSong = _client.CurrentPlaybackName;
-            return SingleResultInList("Remove", $"Remove '{currentSong}' from liked songs", action: _client.RemoveLikeCurrentSong);
+            return SingleResultInList("Remove", $"Remove '{currentSong}' from liked songs", action: _client.UnlikeCurrentSong);
         }
 
         private List<Result> ToggleLikeCurrentSong(string arg = null)

--- a/SpotifyPluginClient.cs
+++ b/SpotifyPluginClient.cs
@@ -287,7 +287,7 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
             }
             else
             {
-                RemoveLikeById(trackId);
+                UnlikeById(trackId);
             }
         }
 
@@ -297,7 +297,7 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
             _spotifyClient.Library.SaveTracks(likeRequest);
         }
 
-        public void RemoveLikeById(string trackId) {
+        public void UnlikeById(string trackId) {
             var likeRemoveRequest = new LibraryRemoveTracksRequest(new List<string> {trackId});
             _spotifyClient.Library.RemoveTracks(likeRemoveRequest);
         }
@@ -308,9 +308,9 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
             LikeById(currentSongId);
         }
 
-        public void RemoveLikeCurrentSong() {
+        public void UnlikeCurrentSong() {
             var currentSongId = CurrentPlaybackId;
-            RemoveLikeById(currentSongId);
+            UnlikeById(currentSongId);
         }
     
         public void ToggleLikeCurrentSong() {


### PR DESCRIPTION
This pull request includes changes to the Spotify plugin to improve the handling of "like" and "unlike" commands. The most important changes include updating command names and modifying methods for better consistency and functionality.

### Command Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R34): Updated the `sp like` command to accept a track name and added a new `sp unlike` command to remove the playing track from liked songs.

### Method Renaming and Refactoring:
* [`SpotifyPlugin.cs`](diffhunk://#diff-1bfa7aba7b2a230357136cb37f9396c44e62b66ea3fa23d309de69582ad79faaL68-R69): Renamed methods related to liking and unliking songs to improve clarity and consistency. [[1]](diffhunk://#diff-1bfa7aba7b2a230357136cb37f9396c44e62b66ea3fa23d309de69582ad79faaL68-R69) [[2]](diffhunk://#diff-1bfa7aba7b2a230357136cb37f9396c44e62b66ea3fa23d309de69582ad79faaL349-R351)
* [`SpotifyPluginClient.cs`](diffhunk://#diff-0ed9103ee97c67b8d468950d9a4ab6151af1a08c0467d58575fa01d6dfc6420dL300-R300): Renamed methods to `UnlikeById` and `UnlikeCurrentSong` for better readability and consistency. [[1]](diffhunk://#diff-0ed9103ee97c67b8d468950d9a4ab6151af1a08c0467d58575fa01d6dfc6420dL300-R300) [[2]](diffhunk://#diff-0ed9103ee97c67b8d468950d9a4ab6151af1a08c0467d58575fa01d6dfc6420dL311-R313)

### New Functionality:
* [`SpotifyPlugin.cs`](diffhunk://#diff-1bfa7aba7b2a230357136cb37f9396c44e62b66ea3fa23d309de69582ad79faaR495-R529): Added a `SearchLikeTrack` method to handle searching and liking tracks more effectively.