### PR TITLE
Fix build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore -c Release
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: SpotifyPremium
         path: Output/Release/


### PR DESCRIPTION
 The change updates the version of the `upload-artifact` action used in the build process.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L23-R23): Updated the `upload-artifact` action from version `v2` to `v4` to ensure compatibility.